### PR TITLE
Redesign stock worker homepage UI; add interactive panels and WebSocket keepalive

### DIFF
--- a/workers/stock/index.html
+++ b/workers/stock/index.html
@@ -8,97 +8,1056 @@
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/layer/3.5.1/theme/default/layer.min.css">
   <script src="https://cdnjs.cloudflare.com/ajax/libs/layer/3.5.1/layer.min.js"></script>
   <style>
+      :root {
+          color-scheme: light;
+          --bg: #f6f7fb;
+          --card: #ffffff;
+          --text: #1f2a44;
+          --muted: #667085;
+          --accent: #2f6fed;
+          --accent-soft: rgba(47, 111, 237, 0.12);
+          --shadow: 0 8px 30px rgba(15, 23, 42, 0.08);
+      }
+
+      * {
+          box-sizing: border-box;
+      }
+
       .main-body {
-          font-family: "Segoe UI", Arial, sans-serif;
-          background-color: #f9f9f9;
-          color: #555;
+          font-family: "Segoe UI", "PingFang SC", "Microsoft YaHei", Arial, sans-serif;
+          background: var(--bg);
+          color: var(--text);
           margin: 0;
-          padding: 20px;
+      }
+
+      .page {
+          min-height: 100vh;
+          display: flex;
+          flex-direction: column;
+      }
+
+      .topbar {
+          display: flex;
+          align-items: center;
+          justify-content: space-between;
+          padding: 18px 6vw;
+          background: #fff;
+          box-shadow: 0 1px 0 rgba(15, 23, 42, 0.05);
+          position: sticky;
+          top: 0;
+          z-index: 10;
+      }
+
+      .brand {
+          display: flex;
+          align-items: center;
+          gap: 12px;
+          font-weight: 600;
+      }
+
+      .brand-badge {
+          width: 36px;
+          height: 36px;
+          border-radius: 12px;
+          background: var(--accent-soft);
+          display: grid;
+          place-items: center;
+          color: var(--accent);
+          font-weight: 700;
+      }
+
+      .nav-links {
+          display: flex;
+          gap: 20px;
+          font-size: 14px;
+          color: var(--muted);
+      }
+
+      .nav-links span {
+          cursor: default;
+      }
+
+      .action-group {
+          display: flex;
+          align-items: center;
+          gap: 12px;
+      }
+
+      .data-center {
+          position: relative;
+      }
+
+      .data-center-trigger {
+          min-width: 96px;
+      }
+
+      .data-center-menu {
+          position: absolute;
+          top: calc(100% + 10px);
+          right: 0;
+          width: 210px;
+          background: #fff;
+          border: 1px solid #e9edf6;
+          border-radius: 14px;
+          padding: 8px;
+          box-shadow: 0 12px 30px rgba(15, 23, 42, 0.12);
+          opacity: 0;
+          visibility: hidden;
+          transform: translateY(-4px);
+          pointer-events: none;
+          transition: opacity 0.18s ease, transform 0.18s ease;
+          z-index: 30;
+      }
+
+      .data-center.open .data-center-menu {
+          opacity: 1;
+          visibility: visible;
+          transform: translateY(0);
+          pointer-events: auto;
+      }
+
+      .data-center-menu a {
+          display: flex;
+          align-items: center;
+          gap: 8px;
+          text-decoration: none;
+          color: var(--text);
+          border-radius: 10px;
+          padding: 9px 10px;
+          font-size: 13px;
+      }
+
+      .data-center-menu a:hover {
+          background: #f5f8ff;
+          color: var(--accent);
+      }
+
+      .ztlive-draggable-layer .layui-layer-title {
+          cursor: move;
+          user-select: none;
+      }
+
+      .ghost-btn,
+      .primary-btn {
+          border: none;
+          padding: 8px 16px;
+          border-radius: 999px;
+          font-size: 14px;
+          cursor: pointer;
+          transition: all 0.2s ease;
+      }
+
+      .ghost-btn {
+          background: transparent;
+          color: var(--muted);
+      }
+
+      .ghost-btn:hover {
+          background: #f0f2f8;
+          color: var(--text);
+      }
+
+      .primary-btn {
+          background: var(--accent);
+          color: #fff;
+          box-shadow: 0 6px 18px rgba(47, 111, 237, 0.2);
+      }
+
+      .primary-btn:hover {
+          transform: translateY(-1px);
+      }
+
+      .content {
+          flex: 1;
+          padding: 40px 6vw 64px;
+          display: grid;
+          grid-template-columns: minmax(0, 1.4fr) minmax(0, 1fr);
+          gap: 28px;
+      }
+
+      .hero-card {
+          position: relative;
+          overflow: hidden;
+          min-height: 340px;
+          background:
+              radial-gradient(circle at top right, rgba(47, 111, 237, 0.18), transparent 34%),
+              linear-gradient(135deg, #ffffff 0%, #f8fbff 52%, #eef4ff 100%);
+          border: 1px solid rgba(47, 111, 237, 0.08);
+          border-radius: 28px;
+          padding: 32px;
+          box-shadow: var(--shadow);
+          display: flex;
+          flex-direction: column;
+          gap: 20px;
+      }
+
+      .hero-card::after {
+          content: "";
+          position: absolute;
+          right: -56px;
+          bottom: -64px;
+          width: 180px;
+          height: 180px;
+          border-radius: 50%;
+          background: rgba(47, 111, 237, 0.08);
+          pointer-events: none;
+      }
+
+      .hero-copy {
+          position: relative;
+          z-index: 1;
+          flex: 1 1 auto;
+          display: flex;
+          flex-direction: column;
+          justify-content: center;
+          gap: 14px;
+      }
+
+      .hero-eyebrow {
+          width: fit-content;
+          display: inline-flex;
+          align-items: center;
+          gap: 8px;
+          padding: 7px 12px;
+          border-radius: 999px;
+          background: rgba(255, 255, 255, 0.72);
+          color: var(--accent);
+          font-size: 12px;
+          font-weight: 700;
+          box-shadow: 0 8px 20px rgba(47, 111, 237, 0.08);
+      }
+
+      .hero-title {
+          max-width: 580px;
+          font-size: clamp(26px, 3vw, 38px);
+          line-height: 1.18;
+          letter-spacing: -0.03em;
+          margin: 0;
+      }
+
+      .hero-sub {
+          max-width: 620px;
+          font-size: 15px;
+          color: var(--muted);
+          margin: 0;
+          line-height: 1.7;
+      }
+
+      .ai-tool-strip {
+          position: relative;
+          z-index: 1;
+          flex: 0 0 25%;
+          min-height: 116px;
+          display: flex;
+          flex-direction: column;
+          justify-content: flex-end;
+          gap: 12px;
+      }
+
+      .ai-tool-heading {
+          display: flex;
+          align-items: center;
+          justify-content: space-between;
+          gap: 12px;
+          color: var(--muted);
+          font-size: 13px;
+      }
+
+      .ai-tool-heading strong {
+          color: var(--text);
+          font-size: 14px;
+      }
+
+      .ai-tool-grid {
+          display: grid;
+          grid-template-columns: repeat(4, minmax(0, 1fr));
+          gap: 10px;
+      }
+
+      .ai-tool-card {
+          display: flex;
+          align-items: center;
+          gap: 10px;
+          min-height: 58px;
+          padding: 12px;
+          border: 1px solid rgba(226, 232, 240, 0.9);
+          border-radius: 16px;
+          background: rgba(255, 255, 255, 0.82);
+          color: var(--text);
+          text-decoration: none;
+          box-shadow: 0 12px 26px rgba(15, 23, 42, 0.06);
+          backdrop-filter: blur(10px);
+          transition: transform 0.18s ease, border-color 0.18s ease, box-shadow 0.18s ease;
+      }
+
+      .ai-tool-card:hover {
+          transform: translateY(-2px);
+          border-color: rgba(47, 111, 237, 0.32);
+          box-shadow: 0 16px 32px rgba(47, 111, 237, 0.14);
+      }
+
+      .ai-tool-icon {
+          width: 34px;
+          height: 34px;
+          flex: 0 0 34px;
+          display: grid;
+          place-items: center;
+          border-radius: 12px;
+          background: var(--accent-soft);
+          color: var(--accent);
+          font-weight: 800;
+      }
+
+      .ai-tool-name {
+          display: block;
+          font-size: 13px;
+          font-weight: 700;
+      }
+
+      .ai-tool-desc {
+          display: block;
+          margin-top: 2px;
+          color: var(--muted);
+          font-size: 11px;
+      }
+
+      .panel {
+          background: var(--card);
+          border-radius: 20px;
+          padding: 22px;
+          box-shadow: var(--shadow);
+      }
+
+      .panel-header {
+          display: flex;
+          align-items: center;
+          justify-content: space-between;
+          gap: 12px;
+      }
+
+      .preview-toggle {
+          display: inline-flex;
+          align-items: center;
+          gap: 8px;
+          font-size: 12px;
+          color: var(--muted);
+      }
+
+      .preview-toggle input {
+          position: absolute;
+          opacity: 0;
+          pointer-events: none;
+      }
+
+      .toggle-track {
+          width: 40px;
+          height: 22px;
+          border-radius: 999px;
+          background: #e2e8f0;
+          position: relative;
+          transition: background 0.2s ease;
+      }
+
+      .toggle-track::after {
+          content: "";
+          position: absolute;
+          top: 3px;
+          left: 3px;
+          width: 16px;
+          height: 16px;
+          border-radius: 50%;
+          background: #fff;
+          box-shadow: 0 2px 6px rgba(15, 23, 42, 0.15);
+          transition: transform 0.2s ease;
+      }
+
+      .preview-toggle input:checked + .toggle-track {
+          background: rgba(47, 111, 237, 0.4);
+      }
+
+      .preview-toggle input:checked + .toggle-track::after {
+          transform: translateX(18px);
+      }
+
+      .iframe-wrap.is-collapsed {
+          opacity: 0;
+          visibility: hidden;
+          pointer-events: none;
+      }
+
+      .panel h3 {
+          margin-top: 0;
+          margin-bottom: 12px;
+      }
+
+      .panel p {
+          color: var(--muted);
+          margin-top: 0;
+          line-height: 1.6;
+      }
+
+      .panel .tag {
+          display: inline-flex;
+          align-items: center;
+          gap: 6px;
+          background: var(--accent-soft);
+          color: var(--accent);
+          padding: 6px 12px;
+          border-radius: 999px;
+          font-size: 12px;
+          font-weight: 600;
+      }
+
+      .focus-timeline {
+          margin-top: 16px;
+          display: grid;
+          gap: 12px;
+      }
+
+      .timeline-head,
+      .timeline-row {
+          display: grid;
+          grid-template-columns: 96px repeat(4, minmax(0, 1fr));
+          gap: 10px;
+          align-items: stretch;
+      }
+
+      .timeline-head {
+          color: var(--muted);
+          font-size: 12px;
+          padding: 0 2px;
+      }
+
+      .timeline-head span:not(:first-child) {
+          text-align: center;
+      }
+
+      .timeline-role {
+          display: flex;
+          flex-direction: column;
+          justify-content: center;
+          gap: 4px;
+          min-height: 86px;
+          padding: 12px;
+          border-radius: 16px;
+          background: linear-gradient(135deg, #f8fafc, #eef4ff);
+          border: 1px solid #edf0f6;
+      }
+
+      .timeline-role strong {
+          font-size: 14px;
+          color: var(--text);
+      }
+
+      .timeline-role small {
+          color: var(--muted);
+          font-size: 11px;
+      }
+
+      .timeline-slot {
+          position: relative;
+          min-height: 86px;
+          padding: 12px;
+          border: 1px solid #edf0f6;
+          border-radius: 16px;
+          background: rgba(248, 250, 252, 0.78);
+          overflow: visible;
+          cursor: default;
+          transition: transform 0.18s ease, border-color 0.18s ease, box-shadow 0.18s ease, background 0.18s ease;
+      }
+
+      .timeline-slot::before {
+          content: "";
+          position: absolute;
+          top: 18px;
+          left: 12px;
+          right: 12px;
+          height: 2px;
+          border-radius: 999px;
+          background: linear-gradient(90deg, rgba(47, 111, 237, 0.25), rgba(47, 111, 237, 0.05));
+      }
+
+      .timeline-dot {
+          position: relative;
+          z-index: 1;
+          display: block;
+          width: 10px;
+          height: 10px;
+          border-radius: 50%;
+          background: var(--accent);
+          box-shadow: 0 0 0 5px rgba(47, 111, 237, 0.12);
+      }
+
+      .timeline-label {
+          display: block;
+          margin-top: 18px;
+          color: var(--text);
+          font-size: 13px;
+          font-weight: 700;
+      }
+
+      .timeline-hint {
+          display: block;
+          margin-top: 5px;
+          color: var(--muted);
+          font-size: 11px;
+      }
+
+      .timeline-popover {
+          position: absolute;
+          left: 50%;
+          bottom: calc(100% + 10px);
+          z-index: 20;
+          width: min(230px, 78vw);
+          padding: 12px;
+          border-radius: 14px;
+          background: #0f172a;
+          color: #fff;
+          box-shadow: 0 18px 40px rgba(15, 23, 42, 0.22);
+          opacity: 0;
+          visibility: hidden;
+          transform: translate(-50%, 6px);
+          pointer-events: none;
+          transition: opacity 0.16s ease, transform 0.16s ease, visibility 0.16s ease;
+      }
+
+      .timeline-popover::after {
+          content: "";
+          position: absolute;
+          left: 50%;
+          bottom: -6px;
+          width: 12px;
+          height: 12px;
+          background: #0f172a;
+          transform: translateX(-50%) rotate(45deg);
+      }
+
+      .timeline-popover strong {
+          display: block;
+          margin-bottom: 6px;
+          font-size: 13px;
+      }
+
+      .timeline-popover span {
+          display: block;
+          color: rgba(255, 255, 255, 0.78);
+          font-size: 12px;
+          line-height: 1.55;
+      }
+
+      .timeline-slot:hover,
+      .timeline-slot:focus-within {
+          z-index: 3;
+          transform: translateY(-2px);
+          border-color: rgba(47, 111, 237, 0.35);
+          background: #fff;
+          box-shadow: 0 14px 30px rgba(47, 111, 237, 0.12);
+      }
+
+      .timeline-slot:hover .timeline-popover,
+      .timeline-slot:focus-within .timeline-popover {
+          opacity: 1;
+          visibility: visible;
+          transform: translate(-50%, 0);
+      }
+
+      .iframe-wrap {
+          margin-top: 18px;
+          width: 100%;
+          border-radius: 16px;
+          overflow: hidden;
+          border: 1px solid #edf0f6;
+          transition: opacity 0.2s ease;
+      }
+
+      #amount {
+          border: none;
+          width: 100%;
+          min-width: 100%;
+          height: 280px;
+          background: #fff;
+          display: block;
+      }
+
+      .tool-panel {
+          position: fixed;
+          right: 24px;
+          bottom: 24px;
+          width: 260px;
+          background: #0f172a;
+          color: #e2e8f0;
+          border-radius: 16px;
+          padding: 16px;
+          box-shadow: 0 12px 30px rgba(15, 23, 42, 0.35);
+          opacity: 0;
+          transform: translateY(12px);
+          pointer-events: none;
+          transition: all 0.2s ease;
+      }
+
+      .tool-panel.is-open {
+          opacity: 1;
+          transform: translateY(0);
+          pointer-events: auto;
+      }
+
+      .tool-panel h4 {
+          margin: 0 0 10px;
+          font-size: 14px;
+          font-weight: 600;
       }
 
       .menu {
           list-style: none;
           padding: 0;
-          max-width: 260px;
+          margin: 0;
+          display: grid;
+          gap: 8px;
       }
 
       .menu li {
-          background: #fff;
-          margin-bottom: 8px;
-          border-radius: 6px;
-          box-shadow: 0 0 0 rgba(0, 0, 0, 0);
-          transition: all 0.2s ease;
+          background: rgba(255, 255, 255, 0.08);
+          border-radius: 10px;
           padding: 8px 12px;
-          font-size: 14px;
+          font-size: 13px;
+          transition: all 0.2s ease;
       }
 
       .menu li:hover {
-          box-shadow: 0 1px 4px rgba(0, 0, 0, 0.08);
-          background: #f3f3f3;
+          background: rgba(255, 255, 255, 0.16);
       }
 
       .menu a {
           text-decoration: none;
-          color: #555;
+          color: inherit;
           display: flex;
           align-items: center;
+          gap: 6px;
+      }
+
+      .divider {
+          color: rgba(226, 232, 240, 0.4);
+          text-align: center;
+          font-size: 11px;
+          padding: 4px 0;
       }
 
       .icon {
           font-size: 14px;
-          color: #aaa;
-          margin-right: 6px;
+          opacity: 0.7;
       }
 
-      .divider {
-          color: #ccc;
-          text-align: center;
-          font-size: 12px;
-          padding: 4px 0;
+      .footer {
+          padding: 0 6vw 30px;
+          color: var(--muted);
+          font-size: 13px;
+          display: flex;
+          justify-content: space-between;
+          flex-wrap: wrap;
+          gap: 12px;
       }
 
-      #amount {
-          border: none;
-          float: right;
-          margin-top: 234px;
-          width: 60%;
-          height: 280px;
+      .footer details {
           background: #fff;
-          border-radius: 6px;
+          border-radius: 12px;
+          padding: 8px 12px;
+          box-shadow: 0 4px 14px rgba(15, 23, 42, 0.05);
+      }
+
+      .footer summary {
+          cursor: pointer;
+          list-style: none;
+          font-weight: 600;
+          color: var(--text);
+      }
+
+      .footer ul {
+          list-style: none;
+          padding: 8px 0 0;
+          margin: 0;
+          display: grid;
+          gap: 6px;
+      }
+
+      .footer a {
+          color: var(--muted);
+          text-decoration: none;
+      }
+
+      .footer a:hover {
+          color: var(--accent);
+      }
+
+      @media (max-width: 1100px) {
+          .ai-tool-grid {
+              grid-template-columns: repeat(2, minmax(0, 1fr));
+          }
+      }
+
+      @media (max-width: 960px) {
+          .content {
+              grid-template-columns: 1fr;
+          }
+      }
+
+      @media (max-width: 720px) {
+          .topbar {
+              flex-wrap: wrap;
+              gap: 12px;
+          }
+
+          .nav-links {
+              display: none;
+          }
+
+          .content {
+              padding: 28px 6vw 48px;
+          }
+
+          .hero-card {
+              min-height: auto;
+              padding: 24px;
+          }
+
+          .ai-tool-heading {
+              align-items: flex-start;
+              flex-direction: column;
+          }
+
+          .ai-tool-grid {
+              grid-template-columns: 1fr;
+          }
+
+          .focus-timeline {
+              overflow-x: auto;
+              padding-bottom: 4px;
+          }
+
+          .timeline-head,
+          .timeline-row {
+              min-width: 620px;
+          }
       }
   </style>
 </head>
 <body class="main-body">
 
-<ol class="menu">
-  <li><a href="#/news.html" id="news"><span class="icon">📰</span>资讯</a></li>
-  <li><a href="/qxlive.html" target="_blank"><span class="icon"></span>市场情绪</a></li>
-  <li class="divider">──────start</li>
-  <li><a href="https://duanxianxia.cn/web/jjlive" target="_blank"><span class="icon">⏳</span>隔夜单统计</a></li>
-  <li class="divider">──────go</li>
-  <li><a href="#/yidong.html" id="yidong"><span class="icon">📢</span>异动播报</a></li>
-  <li><a href="#/ztlive.html" id="ztlive">实时涨停播报</a></li>
-  <li>
-    <a href="https://wenda.tdx.com.cn/site/wenda/stock_index.html?message=去除st,去除北交所,成交额前100,量比,实际换手率"
-       target="_blank">
-      <span class="icon">🍜</span>问小达
-    </a>
-  </li>
-  <li><a href="https://wenda.tdx.com.cn/site/wenda/page-user-center.html">问小达问句</a></li>
-  <li><a href="#https://duanxianxia.cn/web/fupangu/" id="lianban"><span class="icon">📂</span>复盘古</a></li>
-  <li class="divider">──────end</li>
-  <li><a href="#https://duanxianxia.cn/web/fupan" id="fupan"><span class="icon">📅</span>涨停复盘</a></li>
-  <li><a href="https://data.10jqka.com.cn/financial/yjyg/" target="_blank"><span class="icon">📑</span>业绩报</a></li>
-</ol>
+<div class="page">
+  <header class="topbar">
+    <div class="brand">
+      <div class="brand-badge">DX</div>
+      <div>
+        <div>信息工作台</div>
+        <small class="nav-links">数据清单 · 日常速览 · 智能提醒</small>
+      </div>
+    </div>
+    <div class="action-group">
+      <div class="data-center" id="dataCenter">
+        <button class="ghost-btn data-center-trigger" id="dataCenterTrigger" aria-expanded="false">数据中心 ▾</button>
+        <div class="data-center-menu" id="dataCenterMenu">
+          <a href="https://data.eastmoney.com/report/industry.jshtml" target="_blank" rel="noopener noreferrer">
+            <span>📘</span><span>行业研报</span>
+          </a>
+          <a href="https://www.jiuyangongshe.com/" target="_blank" rel="noopener noreferrer">
+            <span>🌐</span><span>韭研公社</span>
+          </a>
+          <a href="https://724.guzhang.com/" target="_blank" rel="noopener noreferrer">
+            <span>🧭</span><span>聚合资讯</span>
+          </a>
+          <a href="https://xuangutong.com.cn/top-gainer" target="_blank" rel="noopener noreferrer">
+            <span>🔥</span><span>热点解读</span>
+          </a>
+        </div>
+      </div>
+      <button class="ghost-btn" id="toggleTools">辅助入口</button>
+      <button class="primary-btn" id="openNews">立即查看</button>
+    </div>
+  </header>
 
-<iframe src="https://www.duanxianxia.cn/web/amount" id="amount" name="amount"></iframe>
+  <main class="content">
+    <section class="hero-card">
+      <div class="hero-copy">
+        <span class="hero-eyebrow">✨ 工作台已就绪</span>
+        <h1 class="hero-title">欢迎回来，今日内容已准备就绪。</h1>
+        <p class="hero-sub">首页保持常规信息门户风格，常用入口以轻量卡片呈现，辅助功能收纳在浮层中，打开后依然保持清晰易用。</p>
+      </div>
+      <div class="ai-tool-strip" aria-label="AI 对话工具">
+        <div class="ai-tool-heading">
+          <strong>AI 对话工具</strong>
+          <span>常用助手一键打开，四列排布更紧凑。</span>
+        </div>
+        <div class="ai-tool-grid">
+          <a class="ai-tool-card" href="https://z.ai/chat" target="_blank" rel="noopener noreferrer">
+            <span class="ai-tool-icon">Z</span>
+            <span><span class="ai-tool-name">Z.ai</span><span class="ai-tool-desc">轻量对话</span></span>
+          </a>
+          <a class="ai-tool-card" href="https://chat.deepseek.com/" target="_blank" rel="noopener noreferrer">
+            <span class="ai-tool-icon">D</span>
+            <span><span class="ai-tool-name">DeepSeek</span><span class="ai-tool-desc">深度推理</span></span>
+          </a>
+          <a class="ai-tool-card" href="https://chatgpt.com/" target="_blank" rel="noopener noreferrer">
+            <span class="ai-tool-icon">G</span>
+            <span><span class="ai-tool-name">ChatGPT</span><span class="ai-tool-desc">综合助手</span></span>
+          </a>
+          <a class="ai-tool-card" href="https://gemini.google.com/" target="_blank" rel="noopener noreferrer">
+            <span class="ai-tool-icon">✦</span>
+            <span><span class="ai-tool-name">Gemini</span><span class="ai-tool-desc">Google AI</span></span>
+          </a>
+          <a class="ai-tool-card" href="https://chatglm.cn/" target="_blank" rel="noopener noreferrer">
+            <span class="ai-tool-icon">智</span>
+            <span><span class="ai-tool-name">智谱清言 Agent</span><span class="ai-tool-desc">国产助手</span></span>
+          </a>
+        </div>
+      </div>
+    </section>
+
+    <section class="panel">
+      <div class="panel-header">
+        <h3>今日概览</h3>
+        <label class="preview-toggle">
+          <input type="checkbox" id="togglePreview" checked>
+          <span class="toggle-track"></span>
+          <span class="toggle-label">显示</span>
+        </label>
+      </div>
+      <p>默认展示类似资讯门户的卡片布局，内嵌的数据保持在可视区域，避免突兀。</p>
+      <div class="iframe-wrap" id="previewFrame">
+        <iframe src="https://www.duanxianxia.cn/web/amount" id="amount" name="amount" width="100%" height="280"></iframe>
+      </div>
+    </section>
+
+    <section class="panel">
+      <h3>关注点整理</h3>
+      <p>以日常工作流方式整理常用入口，默认只呈现轻量节奏视图；悬浮在节点上可查看该角色在当前阶段适合打开的工具。</p>
+      <div class="focus-timeline" aria-label="双角色横向时间轴">
+        <div class="timeline-head" aria-hidden="true">
+          <span></span>
+          <span>启动</span>
+          <span>收集</span>
+          <span>跟进</span>
+          <span>复核</span>
+        </div>
+        <div class="timeline-row">
+          <div class="timeline-role">
+            <strong>程序员</strong>
+            <small>构建 / 排查</small>
+          </div>
+          <div class="timeline-slot" tabindex="0">
+            <span class="timeline-dot"></span>
+            <span class="timeline-label">环境确认</span>
+            <span class="timeline-hint">悬浮查看</span>
+            <div class="timeline-popover"><strong>可能使用</strong><span>AI 对话工具、问句中心、入口状态检查。</span></div>
+          </div>
+          <div class="timeline-slot" tabindex="0">
+            <span class="timeline-dot"></span>
+            <span class="timeline-label">资料整理</span>
+            <span class="timeline-hint">悬浮查看</span>
+            <div class="timeline-popover"><strong>可能使用</strong><span>数据中心、聚合资讯、专题资料。</span></div>
+          </div>
+          <div class="timeline-slot" tabindex="0">
+            <span class="timeline-dot"></span>
+            <span class="timeline-label">问题跟进</span>
+            <span class="timeline-hint">悬浮查看</span>
+            <div class="timeline-popover"><strong>可能使用</strong><span>辅助入口、实时提醒、变更窗口。</span></div>
+          </div>
+          <div class="timeline-slot" tabindex="0">
+            <span class="timeline-dot"></span>
+            <span class="timeline-label">结果复核</span>
+            <span class="timeline-hint">悬浮查看</span>
+            <div class="timeline-popover"><strong>可能使用</strong><span>归档记录、清单对照、AI 总结。</span></div>
+          </div>
+        </div>
+        <div class="timeline-row">
+          <div class="timeline-role">
+            <strong>信息观察者</strong>
+            <small>阅读 / 记录</small>
+          </div>
+          <div class="timeline-slot" tabindex="0">
+            <span class="timeline-dot"></span>
+            <span class="timeline-label">晨间速览</span>
+            <span class="timeline-hint">悬浮查看</span>
+            <div class="timeline-popover"><strong>可能使用</strong><span>今日概览、聚合资讯、AI 摘要。</span></div>
+          </div>
+          <div class="timeline-slot" tabindex="0">
+            <span class="timeline-dot"></span>
+            <span class="timeline-label">线索归档</span>
+            <span class="timeline-hint">悬浮查看</span>
+            <div class="timeline-popover"><strong>可能使用</strong><span>线索解读、资料入口、观察清单。</span></div>
+          </div>
+          <div class="timeline-slot" tabindex="0">
+            <span class="timeline-dot"></span>
+            <span class="timeline-label">即时观察</span>
+            <span class="timeline-hint">悬浮查看</span>
+            <div class="timeline-popover"><strong>可能使用</strong><span>轻量提醒、状态面板、临时记录。</span></div>
+          </div>
+          <div class="timeline-slot" tabindex="0">
+            <span class="timeline-dot"></span>
+            <span class="timeline-label">收尾整理</span>
+            <span class="timeline-hint">悬浮查看</span>
+            <div class="timeline-popover"><strong>可能使用</strong><span>复核入口、留存清单、AI 归纳。</span></div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="panel">
+      <h3>情绪概览</h3>
+      <p>快速阅读短线情绪走势，保持外观为资讯页面的常态。</p>
+      <a class="tag" href="/qxlive.html" target="_blank">打开情绪面板</a>
+    </section>
+  </main>
+
+  <footer class="footer">
+    <span>数据源已对齐，呈现为常规门户风格。</span>
+    <details>
+      <summary>更多入口</summary>
+      <ul>
+        <li><a href="https://data.10jqka.com.cn/financial/yjyg/" target="_blank">业绩报</a></li>
+        <li><a href="https://wenda.tdx.com.cn/site/wenda/page-user-center.html" target="_blank">问小达问句</a></li>
+        <li><a href="#jjlive" class="jjlive-link">隔夜单统计</a></li>
+      </ul>
+    </details>
+  </footer>
+</div>
+
+<aside class="tool-panel" id="toolPanel">
+  <h4>辅助入口</h4>
+  <ol class="menu">
+    <li><a href="#/news.html" id="news"><span class="icon">📰</span>资讯</a></li>
+    <li><a href="/qxlive.html" target="_blank"><span class="icon">📊</span>情绪面板</a></li>
+    <li class="divider">──────start</li>
+    <li><a href="#jjlive" class="jjlive-link"><span class="icon">⏳</span>隔夜单统计</a></li>
+    <li class="divider">──────go</li>
+    <li><a href="#/yidong.html" id="yidong"><span class="icon">📢</span>异动播报</a></li>
+    <li><a href="#/ztlive.html" id="ztlive"><span class="icon">🟢</span>实时涨停播报</a></li>
+    <li>
+      <a href="https://wenda.tdx.com.cn/site/wenda/stock_index.html?message=去除st,去除北交所,成交额前100,量比,实际换手率"
+         target="_blank">
+        <span class="icon">🍜</span>问小达
+      </a>
+    </li>
+    <li><a href="https://wenda.tdx.com.cn/site/wenda/page-user-center.html" target="_blank">问小达问句</a></li>
+    <li><a href="#https://duanxianxia.cn/web/fupangu/" id="lianban"><span class="icon">📂</span>复盘古</a></li>
+    <li class="divider">──────end</li>
+    <li><a href="#https://duanxianxia.cn/web/fupan" id="fupan"><span class="icon">📅</span>涨停复盘</a></li>
+    <li><a href="https://data.10jqka.com.cn/financial/yjyg/" target="_blank"><span class="icon">📑</span>业绩报</a></li>
+  </ol>
+</aside>
 
 <script>
+  $('#toggleTools').on('click', function () {
+    $('#toolPanel').toggleClass('is-open')
+  })
+
+  var dataCenter = $('#dataCenter')
+  var dataCenterTrigger = $('#dataCenterTrigger')
+  var dataCenterMenu = $('#dataCenterMenu')
+  var dataCenterTimer
+
+  function setDataCenterOpen(open) {
+    dataCenter.toggleClass('open', open)
+    dataCenterTrigger.attr('aria-expanded', open ? 'true' : 'false')
+    dataCenterTrigger.text(open ? '数据中心 ▴' : '数据中心 ▾')
+  }
+
+  function queueDataCenterClose(delay) {
+    clearTimeout(dataCenterTimer)
+    dataCenterTimer = setTimeout(function () {
+      setDataCenterOpen(false)
+    }, delay || 120)
+  }
+
+  dataCenterTrigger.on('click', function (event) {
+    event.preventDefault()
+    event.stopPropagation()
+    clearTimeout(dataCenterTimer)
+    setDataCenterOpen(!dataCenter.hasClass('open'))
+  })
+
+  dataCenter.on('mouseenter', function () {
+    clearTimeout(dataCenterTimer)
+    setDataCenterOpen(true)
+  })
+
+  dataCenter.on('mouseleave', function () {
+    queueDataCenterClose(180)
+  })
+
+  dataCenterMenu.on('click', function (event) {
+    event.stopPropagation()
+  })
+
+  $(document).on('click', function () {
+    setDataCenterOpen(false)
+  })
+
+  $(document).on('keydown', function (event) {
+    if (event.key === 'Escape') {
+      setDataCenterOpen(false)
+    }
+  })
+
+  $('#openNews').on('click', function () {
+    $('#news').trigger('click')
+  })
+
+  var previewToggle = $('#togglePreview')
+  var previewFrame = $('#previewFrame')
+  var previewLabel = previewToggle.closest('.preview-toggle').find('.toggle-label')
+  var previewStorageKey = 'stock_preview_visible'
+
+  function applyPreviewState(isVisible) {
+    previewToggle.prop('checked', isVisible)
+    previewFrame.toggleClass('is-collapsed', !isVisible)
+    previewLabel.text(isVisible ? '显示' : '隐藏')
+    if (isVisible) {
+      var iframe = $('#amount')
+      iframe.css({ width: '100%', minWidth: '100%', height: '280px' })
+      previewFrame[0].offsetHeight
+      requestAnimationFrame(function () {
+        iframe.css({ width: '100%', minWidth: '100%' })
+      })
+    }
+  }
+
+  var savedPreviewState = localStorage.getItem(previewStorageKey)
+  if (savedPreviewState !== null) {
+    applyPreviewState(savedPreviewState === 'true')
+  }
+
+  previewToggle.on('change', function () {
+    var isChecked = $(this).is(':checked')
+    applyPreviewState(isChecked)
+    localStorage.setItem(previewStorageKey, String(isChecked))
+  })
+
+  $('.jjlive-link').on('click', function (event) {
+    event.preventDefault()
+    layer.open({
+      id: 'jjlive_',
+      type: 2,
+      move: true,
+      moveOut: true,
+      area: ['100%', '100%'],
+      title: '隔夜单统计',
+      maxmin: true,
+      offset: 'auto',
+      shade: 0,
+      fixed: false,
+      content: 'https://duanxianxia.cn/web/jjlive',
+      success: function (layero, index) {
+        layer.full(index)
+      }
+    })
+  })
+
   $('#news').click(function () {
     layer.open({
       id: 'newsT',
       type: 2,
       title: '资讯',
+      move: true,
+      moveOut: true,
       maxmin: true,
       area: ['666px', '88%'],
       offset: 'b',
@@ -113,6 +1072,8 @@
       id: 'yidong_',
       type: 2,
       title: '异动播报',
+      move: true,
+      moveOut: true,
       maxmin: false,
       area: ['660px', '600px'],
       offset: 'lb',
@@ -129,6 +1090,10 @@
       id: 'ztliveT',
       type: 2,
       title: '实时涨停播报',
+      skin: 'ztlive-draggable-layer',
+      move: '.layui-layer-title',
+      moveType: 1,
+      moveOut: true,
       maxmin: true,
       area: ['660px', '700px'], // 初始尺寸
       offset: 'rb',
@@ -163,6 +1128,8 @@
     layer.open({
       id: 'lianban_',
       type: 2,
+      move: true,
+      moveOut: true,
       area: ['60%', '100%'],
       title: '昨日涨停',
       maxmin: true,
@@ -177,6 +1144,8 @@
     layer.open({
       id: 'fupan_',
       type: 2,
+      move: true,
+      moveOut: true,
       area: ['100%', '100%'],
       title: '涨停复盘',
       maxmin: true,

--- a/workers/stock/js/web_ztlive.js
+++ b/workers/stock/js/web_ztlive.js
@@ -1070,7 +1070,12 @@ $(function () {
     }
   }
 
-  var _0x159581 = new WebSocket(_0x20fe38[_0x2b6a0a(177, "$l#T")]);
+  var _0x159581 = new WebSocket("wss://m.duanxianxia.com/wss3");
+  var ztlivePingTimer = setInterval(function () {
+    if (_0x159581.readyState === WebSocket.OPEN) {
+      _0x159581.send("ping");
+    }
+  }, 60000);
 
   _0x159581[_0x2b6a0a(609, "p2xk")] = function () {
     _0x159581["send"](_0x20fe38["ZWlxt"]);
@@ -1247,7 +1252,11 @@ $(function () {
         _0x322c0b["parent"]["closekline"]();
       }
     }
-  }, _0x159581[_0x2b6a0a(590, "$tt*")] = function (_0x3929c9) {}, _0x159581["onerror"] = function (_0x2bc8da) {}, setInterval(function () {
+  }, _0x159581[_0x2b6a0a(590, "$tt*")] = function (_0x3929c9) {
+    clearInterval(ztlivePingTimer);
+  }, _0x159581["onerror"] = function (_0x2bc8da) {
+    clearInterval(ztlivePingTimer);
+  }, setInterval(function () {
     var _0x4d16e4 = _0x2b6a0a;
     if (_0x20fe38["TgZQc"](_0x20fe38[_0x4d16e4(671, "M^8r")], _0x20fe38[_0x4d16e4(174, "UzFP")])) var _0x5194d5 = _0x159581["send"](_0x20fe38[_0x4d16e4(148, "RYoR")]);else {
       _0x5d9e7b(this)[_0x4d16e4(504, "UzFP")](_0x4d16e4(154, "Zg(s"))[_0x4d16e4(679, "$COn")](_0x20fe38["xuQVa"])["siblings"]()["removeClass"](_0x4d16e4(585, "p2xk"))["addClass"](_0x20fe38["EQaQm"]), _0x2d21cd = _0x20fe38["QbRbC"](_0x4bd6c0, this)[_0x4d16e4(521, "RYoR")](), _0x1fd7e9 = _0x20fe38["Ilikq"](_0x2377b7, this)[_0x4d16e4(225, "RT%1")](_0x20fe38["YHZkS"]), _0x2b04bf = _0x20fe38[_0x4d16e4(145, "I14X")](_0x2c55be, this)[_0x4d16e4(654, "RYoR")](_0x20fe38[_0x4d16e4(144, "j&^U")]), _0x480493 = _0x20fe38["YRIYc"](_0x3a3f83, this)[_0x4d16e4(363, "dap7")](_0x20fe38["Fbadl"]);


### PR DESCRIPTION
### Motivation
- Modernize and reorganize the stock worker homepage to a clearer, card-based portal layout with better UX and responsive behavior.
- Surface common AI tools and quick-entry items as first-class cards while hiding less-used links in a floating tool panel.
- Provide a persistent preview toggle for the embedded amount iframe to avoid intrusive content by default.
- Improve stability of the realtime `ztlive` WebSocket connection by adding a keepalive ping and proper cleanup on close/error.

### Description
- Rewrote `workers/stock/index.html` layout and styles, introducing CSS variables, a sticky `topbar`, `hero-card`, `panel` components, a responsive grid `content`, `focus-timeline`, and a `footer` with details and links.
- Consolidated previous left menu into a floating `aside.tool-panel` and added interactive controls: `#toggleTools` to open/close the panel and `#dataCenter` dropdown with hover/click behavior implemented via jQuery and ARIA state updates.
- Replaced the old `iframe` placement with an embeddable preview inside `.iframe-wrap` and added a `#togglePreview` checkbox whose state is persisted to `localStorage` under the key `stock_preview_visible` and applied by `applyPreviewState`.
- Enhanced various `layer.open` usages to allow draggable windows (`move`, `moveOut`, `skin: 'ztlive-draggable-layer'`) and ensured `ztlive` modal attempts `layer.iframeAuto` on iframe `load`.
- Updated `workers/stock/js/web_ztlive.js` to connect to `wss://m.duanxianxia.com/wss3`, added a periodic keepalive `ping` every 60s via `ztlivePingTimer`, and clear that interval in `onclose` and `onerror` handlers to avoid orphaned timers.

### Testing
- No automated tests were added or executed for these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69893484dcdc8326858793ab87600b8f)